### PR TITLE
Fetch available Elixir versions from GitHub API

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,24 +1,6 @@
 #!/usr/bin/env bash
 
-versions_list=(
-  1.0.0
-  1.0.1
-  1.0.2
-  1.0.4
-  1.0.5
-  1.1.0
-  1.1.1
-  1.2.0
-  1.2.1
-  1.2.2
-  1.2.3
-)
-
-versions=""
-
-for version in "${versions_list[@]}"
-do
-  versions="${versions} ${version}"
-done
-
+releases_path=https://api.github.com/repos/elixir-lang/elixir/releases
+# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
+versions=$(curl -s $releases_path | grep "tag_name" | cut -d':' -f2 | sed -e 's/["v,]//g')
 echo $versions

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,5 +2,5 @@
 
 releases_path=https://api.github.com/repos/elixir-lang/elixir/releases
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(curl -s $releases_path | grep "tag_name" | cut -d':' -f2 | sed -e 's/["v,]//g')
+versions=$(curl -s $releases_path | grep "tag_name" | cut -d':' -f2 | sed -e 's/["v,]//g' | tr '\n' ' ')
 echo $versions


### PR DESCRIPTION
Three days ago Elixir 1.2.5 was released. When I tried to install it using asdf it was not included in the list of available versions. In fact, the last version included was 1.2.3 (there is an open pull request in #7 to add Elixir 1.2.4 to the list).

Ignoring the fact that the version 1.2.5 was not included, I tried to install it using `asdf install elixir 1.2.5`, which worked flawlessly :+1: 
I decided to take a look at the code and saw that currently, the list of available versions is simply a hardcoded list. Therefore this list must be manually updated to include each Elixir version.

This pull request replaces the hardcoded list of available versions with a list of releases directly fetched from the GitHub API. It works a little bit slower because it has to make a HTTP request, but it will be automatically updated with every new Elixir version.