### PR TITLE
Use Github authentication to list releases

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
 releases_path=https://api.github.com/repos/elixir-lang/elixir/releases
+cmd="curl -s"
+if [ -n "$OAUTH_TOKEN" ]; then
+  cmd="$cmd -H Authorization: token $OAUTH_TOKEN"
+fi
+cmd="$cmd $releases_path"
+
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(curl -s $releases_path | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort -r)
+versions=$(eval $cmd | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort -r)
 echo $versions


### PR DESCRIPTION
As discussed in #13, I added an authorization token so the tests pass on Travis, as it seems a lot of OSX builds use the same IP.