### PR TITLE
Fix 404 download error messages

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -13,8 +13,14 @@ install_elixir() {
 
   # path to the tar file
   local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
-  echo $source_path
   download_source_file $install_type $version $source_path
+
+  if [ "$install_type" = "version" ]
+  then
+    echo "==> Copying release into place"
+  else
+    echo "==> Making the release"
+  fi
 
   # running this in a subshell
   # we don't want to disturb current working dir
@@ -49,23 +55,32 @@ download_source_file() {
   local download_url=$(get_download_url $install_type $version)
 
   # determine if the file exists
-  http_status=$(curl -w %{http_code} -s -o /dev/null $download_url)
+  echo "==> Checking whether specified Elixir release/reference exists..."
+  http_status=$(curl -I -w %{http_code} -s -o /dev/null $download_url)
 
   if [ $http_status -eq 404 ]; then
-    echo -e "\nUnable to download Elixir, Github returned a status code of 404"
-    echo -e "URL: ${download_url}\n\n"
-    echo "View all Elixir releases at:"
-    echo -e "\thttps://github.com/elixir-lang/elixir/releases\n"
+    echo -e """==> Elixir version not found.
+
+GitHub returned a 404 for the following URL:
+
+${download_url}
+
+You can view a list of all Elixir releases by running 'asdf list-all elixir'
+or by visiting https://github.com/elixir-lang/elixir/releases
+"""
 
     if [ "$install_type" = "version" ]; then
-      echo "Note: The Elixir version must start with a v (example: v1.1.1)"
+      echo """Note: If you want to download a specific release of Elixir, please
+specify the full version number (e.g. 1.2.1 instead of 1.3)."""
     else
-      echo "Note: The Elixir version must not start with a v (example: 1.1.1)"
+      echo """Note: If you want to specify a git reference by which to install
+Elixir, it must be a valid git tag or branch (generally of the form v1.2.1)."""
     fi
 
     exit 1 # non zero due to file not existing
   fi
 
+  echo -e """==> Downloading ${version} to ${source_path}"""
   curl -Lo $download_path -C - $download_url
 }
 

--- a/bin/install
+++ b/bin/install
@@ -48,6 +48,24 @@ download_source_file() {
   local download_path=$3
   local download_url=$(get_download_url $install_type $version)
 
+  # determine if the file exists
+  http_status=$(curl -w %{http_code} -s -o /dev/null $download_url)
+
+  if [ $http_status -eq 404 ]; then
+    echo -e "\nUnable to download Elixir, Github returned a status code of 404"
+    echo -e "URL: ${download_url}\n\n"
+    echo "View all Elixir releases at:"
+    echo -e "\thttps://github.com/elixir-lang/elixir/releases\n"
+
+    if [ "$install_type" = "version" ]; then
+      echo "Note: The Elixir version must start with a v (example: v1.1.1)"
+    else
+      echo "Note: The Elixir version must not start with a v (example: 1.1.1)"
+    fi
+
+    exit 1 # non zero due to file not existing
+  fi
+
   curl -Lo $download_path -C - $download_url
 }
 


### PR DESCRIPTION
This PR improves upon the work @fkumro did in #2. Instead of downloading the entire file, we simply check the headers (I passed the `-I` option to `curl`).

Additionally, I've improved the error messages to make them correct.

Another issue related to this problem is #18, which we would be able to close when this get's merged.
