### PR TITLE
changed list-all regex to match 0 or more spaces

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -13,5 +13,5 @@ if sort --help | grep -q -- '-V'; then
 fi
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | $sort_cmd)
+versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | $sort_cmd)
 echo $versions


### PR DESCRIPTION
Hi, calling `asdf list-all elixir` wasn't returning any results for me.
The information coming back from `curl -s` has no spaces between 
tag_name and version for me (ubuntu 16), eg, "tag_name":"v1.2.6".

This just changes the `list-all` regex to match 0 or more spaces between
 tag_name and version.
