### PR TITLE
Let users specify the otp version for precompiled binaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ Elixir plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
 ```
 
+## Elixir Precompiled versions
+
+Precompiled Elixir packages are built by [Bob](https://github.com/hexpm/bob/blob/master/README.md#elixir-builds) whenever
+a git push is made to the elixir-lang repo.
+
+These precompiled packages are built against every officially supported OTP version, however if you only specify the
+elixir version, like `1.4.5`, by default the downloaded binaries would be those compiled against the latest OTP release
+supported by that version. 
+If you however, would like to use a more recent OTP you can append `-otp-${OTP_VERSION}` to the version given to asdf-elixir.
+
+So, for example, to install Elixir 1.5.0-rc.0 and take advantage of the new features it takes from OTP-20 you would install
+
+```shell
+asdf install elixir 1.5.0-rc.0-otp-20
+```
+
+Be sure to also install the coresponding Erlang VM version with asdf-erlang, and to specify both matching versions in
+your `.tool-versions` file.
+
 ## Use
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of Elixir.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ So, for example, to install Elixir 1.5.0-rc.0 and take advantage of the new feat
 asdf install elixir 1.5.0-rc.0-otp-20
 ```
 
-Be sure to also install the coresponding Erlang VM version with asdf-erlang, and to specify both matching versions in
+Be sure to also install the correspoding Erlang VM version with asdf-erlang, and to specify both matching versions in
 your `.tool-versions` file.
 
 ## Use

--- a/bin/install
+++ b/bin/install
@@ -73,7 +73,13 @@ get_download_url() {
 
   if [ "$install_type" = "version" ]
   then
-    echo "https://github.com/elixir-lang/elixir/releases/download/v${version}/Precompiled.zip"
+    if [[ "$version" =~ *"-otp-"* ]] ; then
+       local otp=$(echo $version | sed -e 's/.*-otp-//')
+       version=$(echo $version | sed -e 's/-otp-.*//')
+       echo "https://repo.hex.pm/builds/elixir/v{version}-otp-{otp}.zip"
+    else
+       echo "https://repo.hex.pm/builds/elixir/v${version}.zip"
+    fi
   else
     echo "https://github.com/elixir-lang/elixir/archive/${version}.tar.gz"
   fi


### PR DESCRIPTION
Previously we just installed the precompiled Elixir binaries
for the latest supported OTP version. However sometimes people
would need the binaries to have been compiled against a more
recent OTP release.

This patch lets you append '-otp-${OTP_VERSION}' to any installable
version to fix this issue.

Closes #27