### PR TITLE
Don't set MIX env if ASDF version is system

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-if [ "$MIX_ARCHIVES" = "" ]; then
+if [ "$MIX_ARCHIVES" = "" ] && [ "$ASDF_INSTALL_VERSION" != "system" ]; then
   export MIX_ARCHIVES=$ASDF_INSTALL_PATH/.mix/archives
 fi
 
-if [ "$MIX_HOME" = "" ]; then
+if [ "$MIX_HOME" = "" ] && [ "$ASDF_INSTALL_VERSION" != "system" ]; then
   export MIX_HOME=$ASDF_INSTALL_PATH/.mix
 fi
 


### PR DESCRIPTION
When the default version of elixir is `system` it's an error set MIX env