### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ These precompiled packages are built against every officially supported OTP vers
 elixir version, like `1.4.5`, the downloaded binaries will be those compiled against the oldest OTP release
 supported by that version.
 
-If you would like to use precompiled binaries built with a more recent OTP, you can append `-otp-${OTP_VERSION}` to any installable version that can be given to asdf-elixir.
+If you would like to use precompiled binaries built with a more recent OTP, you can append `-otp-${OTP_MAJOR_VERSION}` to any installable version that can be given to asdf-elixir.
 
 So, for example, to install Elixir 1.5.0 and take advantage of the new features from OTP-20 you might install version `1.5.0-otp-20`.
 


### PR DESCRIPTION
The current docs suggest that

> If you would like to use precompiled binaries built with a more recent OTP, you can append `-otp-${OTP_VERSION}` to any installable version that can be given to asdf-elixir.

As I'm using Elixir/OTP 20.2.2, I expected to be able to install `elixir 1.6.1-otp-20.2.2`:

```sh
$ asdf install elixir 1.6.1-otp-20.2.2
/…/elixir-precompiled-1.6.1-otp-20.2.2.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   243    0   243    0     0    729      0 --:--:-- --:--:-- --:--:--   729
[/…/elixir-precompiled-1.6.1-otp-20.2.2.zip]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /…/elixir-precompiled-1.6.1-otp-20.2.2.zip or
        /…/elixir-precompiled-1.6.1-otp-20.2.2.zip.zip, and cannot find /…/elixir-precompiled-1.6.1-otp-20.2.2.zip.ZIP, period.
```

Bob seems to build Elixir for every officially supported OTP version, but from [what I can see](https://github.com/hexpm/bob/blob/master/README.md#elixir-builds):

> These builds are available at `https://repo.hex.pm/builds/elixir/{REF}-otp-{OTP_MAJOR_VERSION}.zip` […]

it is only builds precompiled off of the major versions of OTP that are exposed. 

Installing `elixir 1.6.1-otp-20` worked:

```sh
$ asdf install elixir 1.6.1-otp-20
# …
$ elixir --version
Erlang/OTP 20 [erts-9.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.6.1 (compiled with OTP 20)
```

Hence, I'm suggesting to replace `-otp-${OTP_VERSION}` by `-otp-${OTP_MAJOR_VERSION}` for improved clarity.