### PR TITLE
Make list-all list up to 100 Elixir versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/elixir-lang/elixir/releases
+releases_path=https://api.github.com/repos/elixir-lang/elixir/releases?per_page=100
 cmd="curl -s"
 if [ -n "$OAUTH_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"


### PR DESCRIPTION
Currently `asdf list-all elixir` displays only the last 30 versions. This is due to pagination in the GitHub API. This pull request aims to fix this behaviour by asking 100 items per page, which is the maximum accepted by the API.

This fix works for now, but as soon as we will reach the 101st release we’ll need to make multiple requests to GitHub.