### PR TITLE
Use Bob the Builder's list of Elixir builds instead of GitHub tags

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/elixir-lang/elixir/releases?per_page=100
-cmd="curl -s"
-if [ -n "$OAUTH_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"
-fi
-cmd="$cmd $releases_path"
+releases_path="https://repo.hex.pm/builds/elixir/builds.txt"
+cmd="curl -s $releases_path"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
+# and adapted
 function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+  sed 'h; s/.p\([[:digit:]]\)/.z\1/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort_versions)
+# Fetch all built versions,
+# get only first column,
+# remove all major.minor versions leaving only major.minor.patch versions,
+# remove the v prefix, eg v1.0.0 -> 1.0.0
+# sort the versions
+versions=$(eval $cmd | cut -d\  -f1 | awk -F'.' 'NF!=2' | sed 's/v//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
Use [Bob the Builder's](https://github.com/hexpm/bob) list of available builds instead of [Elixir's GitHub tags](https://github.com/elixir-lang/elixir/tags). 

This list is published at https://repo.hex.pm/builds/elixir/builds.txt. @ericmj I assume this is ok to use?

There are some differences:

- anyone using 0.12.3 or earlier won't have their version show up anymore. But, using master now, running `asdf install elixir 0.7.2` doesn't work anyway.
- Bob the Builder builds a `major.minor` version as well as `major.minor.patch` which isn't helpful for asdf's use case to lock versions. I've stripped these from the output so they don't show up. I do this by removing any line that only has one `.` character.
- RC versions now show up.
- OTP versions now show up.
- master now shows up.

Here's the diff of `asdf list-all elixir` output, between master and this branch:
```patch
-0.7.2
-0.8.0
-0.8.1
-0.8.2
-0.8.3
-0.9.0
-0.9.1
-0.9.2
-0.9.3
-0.10.0
-0.10.1
-0.10.2
-0.10.3
-0.11.0
-0.11.1
-0.11.2
-0.12.0
-0.12.1
-0.12.2
-0.12.3
 0.12.4
 0.12.5
 0.13.0
@@ -31,60 +11,210 @@
 0.15.0
 0.15.1
 1.0.0
+1.0.0-otp-17
+1.0.0-rc1
+1.0.0-rc1-otp-17
+1.0.0-rc2
+1.0.0-rc2-otp-17
 1.0.1
+1.0.1-otp-17
 1.0.2
+1.0.2-otp-17
 1.0.3
+1.0.3-otp-17
 1.0.4
+1.0.4-otp-17
 1.0.5
+1.0.5-otp-17
+1.0.5-otp-18
+1.1.0-rc.0
+1.1.0-rc.0-otp-17
+1.1.0-rc.0-otp-18
 1.1.0
+1.1.0-otp-17
+1.1.0-otp-18
 1.1.1
+1.1.1-otp-17
+1.1.1-otp-18
+1.2.0-rc.0
+1.2.0-rc.0-otp-18
+1.2.0-rc.1
+1.2.0-rc.1-otp-18
 1.2.0
+1.2.0-otp-18
 1.2.1
+1.2.1-otp-18
 1.2.2
+1.2.2-otp-18
 1.2.3
+1.2.3-otp-18
 1.2.4
+1.2.4-otp-18
 1.2.5
+1.2.5-otp-18
 1.2.6
+1.2.6-otp-18
 1.3.0-rc.0
+1.3.0-rc.0-otp-18
+1.3.0-rc.0-otp-19
 1.3.0-rc.1
+1.3.0-rc.1-otp-18
+1.3.0-rc.1-otp-19
 1.3.0
+1.3.0-otp-18
+1.3.0-otp-19
 1.3.1
+1.3.1-otp-18
+1.3.1-otp-19
 1.3.2
+1.3.2-otp-18
+1.3.2-otp-19
 1.3.3
+1.3.3-otp-18
+1.3.3-otp-19
 1.3.4
+1.3.4-otp-18
+1.3.4-otp-19
 1.4.0-rc.0
+1.4.0-rc.0-otp-18
+1.4.0-rc.0-otp-19
+1.4.0-rc.0-otp-20
 1.4.0-rc.1
+1.4.0-rc.1-otp-18
+1.4.0-rc.1-otp-19
+1.4.0-rc.1-otp-20
 1.4.0
+1.4.0-otp-18
+1.4.0-otp-19
 1.4.1
+1.4.1-otp-18
+1.4.1-otp-19
 1.4.2
+1.4.2-otp-18
+1.4.2-otp-19
 1.4.3
+1.4.3-otp-18
+1.4.3-otp-19
 1.4.4
+1.4.4-otp-18
+1.4.4-otp-19
 1.4.5
+1.4.5-otp-18
+1.4.5-otp-19
+1.4.5-otp-20
 1.5.0-rc.0
+1.5.0-rc.0-otp-18
+1.5.0-rc.0-otp-19
+1.5.0-rc.0-otp-20
 1.5.0-rc.1
+1.5.0-rc.1-otp-18
+1.5.0-rc.1-otp-19
+1.5.0-rc.1-otp-20
 1.5.0-rc.2
+1.5.0-rc.2-otp-18
+1.5.0-rc.2-otp-19
+1.5.0-rc.2-otp-20
 1.5.0
+1.5.0-otp-18
+1.5.0-otp-19
+1.5.0-otp-20
 1.5.1
+1.5.1-otp-18
+1.5.1-otp-19
+1.5.1-otp-20
 1.5.2
+1.5.2-otp-18
+1.5.2-otp-19
+1.5.2-otp-20
 1.5.3
+1.5.3-otp-18
+1.5.3-otp-19
+1.5.3-otp-20
 1.6.0-rc.0
+1.6.0-rc.0-otp-19
+1.6.0-rc.0-otp-20
 1.6.0-rc.1
+1.6.0-rc.1-otp-19
+1.6.0-rc.1-otp-20
 1.6.0
+1.6.0-otp-19
+1.6.0-otp-20
 1.6.1
+1.6.1-otp-19
+1.6.1-otp-20
 1.6.2
+1.6.2-otp-19
+1.6.2-otp-20
 1.6.3
+1.6.3-otp-19
+1.6.3-otp-20
 1.6.4
+1.6.4-otp-19
+1.6.4-otp-20
 1.6.5
+1.6.5-otp-19
+1.6.5-otp-20
+1.6.5-otp-21
 1.6.6
+1.6.6-otp-19
+1.6.6-otp-20
+1.6.6-otp-21
 1.7.0-rc.0
+1.7.0-rc.0-otp-19
+1.7.0-rc.0-otp-20
+1.7.0-rc.0-otp-21
+1.7.0-rc.0-otp-22
 1.7.0-rc.1
+1.7.0-rc.1-otp-19
+1.7.0-rc.1-otp-20
+1.7.0-rc.1-otp-21
+1.7.0-rc.1-otp-22
 1.7.0
+1.7.0-otp-19
+1.7.0-otp-20
+1.7.0-otp-21
+1.7.0-otp-22
 1.7.1
+1.7.1-otp-19
+1.7.1-otp-20
+1.7.1-otp-21
+1.7.1-otp-22
 1.7.2
+1.7.2-otp-19
+1.7.2-otp-20
+1.7.2-otp-21
+1.7.2-otp-22
 1.7.3
+1.7.3-otp-19
+1.7.3-otp-20
+1.7.3-otp-21
+1.7.3-otp-22
 1.7.4
+1.7.4-otp-19
+1.7.4-otp-20
+1.7.4-otp-21
+1.7.4-otp-22
 1.8.0-rc.0
+1.8.0-rc.0-otp-20
+1.8.0-rc.0-otp-21
+1.8.0-rc.0-otp-22
 1.8.0-rc.1
+1.8.0-rc.1-otp-20
+1.8.0-rc.1-otp-21
+1.8.0-rc.1-otp-22
 1.8.0
+1.8.0-otp-20
+1.8.0-otp-21
+1.8.0-otp-22
 1.8.1
+1.8.1-otp-20
+1.8.1-otp-21
+1.8.1-otp-22
 1.8.2
+1.8.2-otp-20
+1.8.2-otp-21
+1.8.2-otp-22
+master
+master-otp-20
+master-otp-21
+master-otp-22
```

Resolves #50 