### PR TITLE
Invert inner installation conditional

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -25,7 +25,14 @@ install_elixir() {
   # running this in a subshell
   # we don't want to disturb current working dir
   (
-    if [ "$install_type" != "version" ]; then
+    if [ "$install_type" = "version" ]; then
+      if ! type "unzip" &> /dev/null; then
+        echo "ERROR: unzip not found"
+        exit 1
+      fi
+
+      unzip -q $source_path -d $install_path || exit 1
+    else
       tar zxf $source_path -C $install_path --strip-components=1 || exit 1
       cd $install_path
       make clean test
@@ -34,13 +41,6 @@ install_elixir() {
         rm -rf $install_path
         exit 1
       fi
-    else
-      if ! type "unzip" &> /dev/null; then
-        echo "ERROR: unzip not found"
-        exit 1
-      fi
-
-      unzip -q $source_path -d $install_path || exit 1
     fi
 
     mkdir -p $install_path/.mix/archives


### PR DESCRIPTION
Why:

* The conditional branch is using a negative comparison but it defines
  both branches, breaking the consistency of these checks throughout the
  install script.

Note: this is the first change in a series towards simplifying a bit the code in the install script, to improve robustness, readability, and debugging. Hope it's welcome :smile: 