### PR TITLE
Update elixir version not found message in install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -61,12 +61,11 @@ download_source_file() {
   if [ $http_status -eq 404 ]; then
     echo -e """==> Elixir version not found.
 
-GitHub returned a 404 for the following URL:
+Release server returned a 404 for the following URL:
 
 ${download_url}
 
-You can view a list of all Elixir releases by running 'asdf list-all elixir'
-or by visiting https://github.com/elixir-lang/elixir/releases
+You can view a list of all Elixir releases by running 'asdf list-all elixir'.
 """
 
     if [ "$install_type" = "version" ]; then


### PR DESCRIPTION
Why:

* When the connection to the releases server fails the error message
  redirects users to the Elixir repo on GitHub. However known versions
  are installed from hex.pm.