### PR TITLE
Simplify install script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -11,12 +11,10 @@ install_elixir() {
     local tmp_download_dir=$TMPDIR
   fi
 
-  # running install commands in a subshell
-  # we don't want to disturb current working dir
   if [ "$install_type" = "version" ]; then
-    (install_elixir_version $version $install_path $tmp_download_dir)
+    install_elixir_version $version $install_path $tmp_download_dir
   else
-    (install_elixir_ref $version $install_path $tmp_download_dir)
+    install_elixir_ref $version $install_path $tmp_download_dir
   fi
 
   mkdir -p $install_path/.mix/archives
@@ -54,9 +52,12 @@ install_elixir_ref() {
 
   echo "==> Making the release"
 
+  # Expand source archive
   tar zxf $source_path -C $install_path --strip-components=1 || exit 1
-  cd $install_path
-  make clean test
+
+  # Build from source in a subshell
+  # we don't want to disturb current working dir
+  (cd $install_path; make clean test)
 
   if [ $? -ne 0 ]; then
     rm -rf $install_path

--- a/bin/install
+++ b/bin/install
@@ -91,7 +91,7 @@ EOS
     exit 1 # non zero due to file not existing
   fi
 
-  echo "==> Downloading ${version} to ${source_path}"
+  echo "==> Downloading ${version} to ${download_path}"
   curl -Lo $download_path -C - $download_url
 }
 
@@ -123,7 +123,7 @@ EOS
     exit 1 # non zero due to file not existing
   fi
 
-  echo "==> Downloading ${ref} to ${source_path}"
+  echo "==> Downloading ${ref} to ${download_path}"
   curl -Lo $download_path -C - $download_url
 }
 

--- a/bin/install
+++ b/bin/install
@@ -75,7 +75,8 @@ download_source_file_for_version() {
   http_status=$(curl -I -w %{http_code} -s -o /dev/null $download_url)
 
   if [ $http_status -eq 404 ]; then
-    echo -e """==> Elixir version not found.
+    cat <<EOS
+==> Elixir version not found.
 
 Hex.pm returned a 404 for the following URL:
 
@@ -84,12 +85,13 @@ ${download_url}
 You can view a list of all Elixir releases by running 'asdf list-all elixir'.
 
 Note: If you want to download a specific release of Elixir, please
-specify the full version number (e.g. 1.2.1 instead of 1.3)."""
+specify the full version number (e.g. 1.2.1 instead of 1.3).
+EOS
 
     exit 1 # non zero due to file not existing
   fi
 
-  echo -e """==> Downloading ${version} to ${source_path}"""
+  echo "==> Downloading ${version} to ${source_path}"
   curl -Lo $download_path -C - $download_url
 }
 
@@ -104,7 +106,8 @@ download_source_file_for_ref() {
   http_status=$(curl -I -w %{http_code} -s -o /dev/null $download_url)
 
   if [ $http_status -eq 404 ]; then
-    echo -e """==> Elixir reference not found.
+    cat <<EOS
+==> Elixir reference not found.
 
 GitHub returned a 404 for the following URL:
 
@@ -114,12 +117,13 @@ You can view a list of all Elixir releases by running 'asdf list-all elixir'
 or by visiting https://github.com/elixir-lang/elixir/releases
 
 Note: If you want to specify a git reference by which to install
-Elixir, it must be a valid git tag or branch (generally of the form v1.2.1)."""
+Elixir, it must be a valid git tag or branch (generally of the form v1.2.1).
+EOS
 
     exit 1 # non zero due to file not existing
   fi
 
-  echo -e """==> Downloading ${ref} to ${source_path}"""
+  echo "==> Downloading ${ref} to ${source_path}"
   curl -Lo $download_path -C - $download_url
 }
 

--- a/bin/install
+++ b/bin/install
@@ -11,71 +11,80 @@ install_elixir() {
     local tmp_download_dir=$TMPDIR
   fi
 
-  # path to the tar file
-  local source_path=$(get_download_file_path $install_type $version $tmp_download_dir)
-  download_source_file $install_type $version $source_path
-
-  if [ "$install_type" = "version" ]
-  then
-    echo "==> Copying release into place"
+  # running install commands in a subshell
+  # we don't want to disturb current working dir
+  if [ "$install_type" = "version" ]; then
+    (install_elixir_version $version $install_path $tmp_download_dir)
   else
-    echo "==> Making the release"
+    (install_elixir_ref $version $install_path $tmp_download_dir)
   fi
 
-  # running this in a subshell
-  # we don't want to disturb current working dir
-  (
-    if [ "$install_type" = "version" ]; then
-      if ! type "unzip" &> /dev/null; then
-        echo "ERROR: unzip not found"
-        exit 1
-      fi
-
-      unzip -q $source_path -d $install_path || exit 1
-    else
-      tar zxf $source_path -C $install_path --strip-components=1 || exit 1
-      cd $install_path
-      make clean test
-
-      if [ $? -ne 0 ]; then
-        rm -rf $install_path
-        exit 1
-      fi
-    fi
-
-    mkdir -p $install_path/.mix/archives
-  )
+  mkdir -p $install_path/.mix/archives
 }
 
 
-download_source_file() {
-  local install_type=$1
-  local version=$2
-  local download_path=$3
-  local download_url=$(get_download_url $install_type $version)
+install_elixir_version() {
+  local version=$1
+  local install_path=$2
+  local tmp_download_dir=$3
+
+  # path to the tar file
+  local source_path=$(get_download_file_path_for_version $version $tmp_download_dir)
+  download_source_file_for_version $version $source_path
+
+  echo "==> Copying release into place"
+
+  if ! type "unzip" &> /dev/null; then
+    echo "ERROR: unzip not found"
+    exit 1
+  fi
+
+  unzip -q $source_path -d $install_path || exit 1
+}
+
+
+install_elixir_ref() {
+  local ref=$1
+  local install_path=$2
+  local tmp_download_dir=$3
+
+  # path to the tar file
+  local source_path=$(get_download_file_path_for_ref $ref $tmp_download_dir)
+  download_source_file_for_ref $ref $source_path
+
+  echo "==> Making the release"
+
+  tar zxf $source_path -C $install_path --strip-components=1 || exit 1
+  cd $install_path
+  make clean test
+
+  if [ $? -ne 0 ]; then
+    rm -rf $install_path
+    exit 1
+  fi
+}
+
+
+download_source_file_for_version() {
+  local version=$1
+  local download_path=$2
+  local download_url=$(get_download_url_for_version $version)
 
   # determine if the file exists
-  echo "==> Checking whether specified Elixir release/reference exists..."
+  echo "==> Checking whether specified Elixir release exists..."
   http_status=$(curl -I -w %{http_code} -s -o /dev/null $download_url)
 
   if [ $http_status -eq 404 ]; then
     echo -e """==> Elixir version not found.
 
-GitHub returned a 404 for the following URL:
+Hex.pm returned a 404 for the following URL:
 
 ${download_url}
 
-You can view a list of all Elixir releases by running 'asdf list-all elixir'
-or by visiting https://github.com/elixir-lang/elixir/releases
-"""
+You can view a list of all Elixir releases by running 'asdf list-all elixir'.
 
-    if [ "$install_type" = "version" ]; then
-      echo """Note: If you want to download a specific release of Elixir, please
+Note: If you want to download a specific release of Elixir, please
 specify the full version number (e.g. 1.2.1 instead of 1.3)."""
-    else
-      echo """Note: If you want to specify a git reference by which to install
-Elixir, it must be a valid git tag or branch (generally of the form v1.2.1)."""
-    fi
 
     exit 1 # non zero due to file not existing
   fi
@@ -85,37 +94,71 @@ Elixir, it must be a valid git tag or branch (generally of the form v1.2.1)."""
 }
 
 
-get_download_file_path() {
-  local install_type=$1
-  local version=$2
-  local tmp_download_dir=$3
+download_source_file_for_ref() {
+  local ref=$1
+  local download_path=$2
+  local download_url=$(get_download_url_for_ref $ref)
 
-  if [ "$install_type" = "version" ]; then
-    local pkg_name="elixir-precompiled-${version}.zip"
-  else
-    local pkg_name="elixir-${install_type}-${version}-src.tar.gz"
+  # determine if the file exists
+  echo "==> Checking whether specified Elixir reference exists..."
+  http_status=$(curl -I -w %{http_code} -s -o /dev/null $download_url)
+
+  if [ $http_status -eq 404 ]; then
+    echo -e """==> Elixir reference not found.
+
+GitHub returned a 404 for the following URL:
+
+${download_url}
+
+You can view a list of all Elixir releases by running 'asdf list-all elixir'
+or by visiting https://github.com/elixir-lang/elixir/releases
+
+Note: If you want to specify a git reference by which to install
+Elixir, it must be a valid git tag or branch (generally of the form v1.2.1)."""
+
+    exit 1 # non zero due to file not existing
   fi
+
+  echo -e """==> Downloading ${ref} to ${source_path}"""
+  curl -Lo $download_path -C - $download_url
+}
+
+
+get_download_file_path_for_version() {
+  local version=$1
+  local tmp_download_dir=$2
+  local pkg_name="elixir-precompiled-${version}.zip"
 
   echo "$tmp_download_dir/$pkg_name"
 }
 
 
-get_download_url() {
-  local install_type=$1
-  local version=$2
+get_download_file_path_for_ref() {
+  local ref=$1
+  local tmp_download_dir=$2
+  local pkg_name="elixir-ref-${ref}-src.tar.gz"
 
-  if [ "$install_type" = "version" ]
-  then
-    if [[ "$version" =~ ^[0-9]+\.* ]] ; then
-       # if version is a release number, prepend v
-       echo "https://repo.hex.pm/builds/elixir/v${version}.zip"
-    else
-       # otherwise it can be a branch name or commit sha
-       echo "https://repo.hex.pm/builds/elixir/${version}.zip"
-    fi
+  echo "$tmp_download_dir/$pkg_name"
+}
+
+
+get_download_url_for_version() {
+  local version=$1
+
+  if [[ "$version" =~ ^[0-9]+\.* ]] ; then
+     # if version is a release number, prepend v
+     echo "https://repo.hex.pm/builds/elixir/v${version}.zip"
   else
-    echo "https://github.com/elixir-lang/elixir/archive/${version}.tar.gz"
+     # otherwise it can be a branch name or commit sha
+     echo "https://repo.hex.pm/builds/elixir/${version}.zip"
   fi
+}
+
+
+get_download_url_for_ref() {
+  local ref=$1
+
+  echo "https://github.com/elixir-lang/elixir/archive/${ref}.tar.gz"
 }
 
 

--- a/bin/install
+++ b/bin/install
@@ -29,7 +29,7 @@ install_elixir_version() {
   local tmp_download_dir=$3
 
   # path to the tar file
-  local source_path=$(get_download_file_path_for_version $version $tmp_download_dir)
+  local source_path="$tmp_download_dir/elixir-precompiled-${version}.zip"
   download_source_file_for_version $version $source_path
 
   echo "==> Copying release into place"
@@ -49,7 +49,7 @@ install_elixir_ref() {
   local tmp_download_dir=$3
 
   # path to the tar file
-  local source_path=$(get_download_file_path_for_ref $ref $tmp_download_dir)
+  local source_path="$tmp_download_dir/elixir-ref-${version}-src.tar.gz"
   download_source_file_for_ref $ref $source_path
 
   echo "==> Making the release"
@@ -97,7 +97,7 @@ specify the full version number (e.g. 1.2.1 instead of 1.3)."""
 download_source_file_for_ref() {
   local ref=$1
   local download_path=$2
-  local download_url=$(get_download_url_for_ref $ref)
+  local download_url="https://github.com/elixir-lang/elixir/archive/${ref}.tar.gz"
 
   # determine if the file exists
   echo "==> Checking whether specified Elixir reference exists..."
@@ -124,24 +124,6 @@ Elixir, it must be a valid git tag or branch (generally of the form v1.2.1)."""
 }
 
 
-get_download_file_path_for_version() {
-  local version=$1
-  local tmp_download_dir=$2
-  local pkg_name="elixir-precompiled-${version}.zip"
-
-  echo "$tmp_download_dir/$pkg_name"
-}
-
-
-get_download_file_path_for_ref() {
-  local ref=$1
-  local tmp_download_dir=$2
-  local pkg_name="elixir-ref-${ref}-src.tar.gz"
-
-  echo "$tmp_download_dir/$pkg_name"
-}
-
-
 get_download_url_for_version() {
   local version=$1
 
@@ -152,13 +134,6 @@ get_download_url_for_version() {
      # otherwise it can be a branch name or commit sha
      echo "https://repo.hex.pm/builds/elixir/${version}.zip"
   fi
-}
-
-
-get_download_url_for_ref() {
-  local ref=$1
-
-  echo "https://github.com/elixir-lang/elixir/archive/${ref}.tar.gz"
 }
 
 

--- a/bin/install
+++ b/bin/install
@@ -131,13 +131,12 @@ EOS
 get_download_url_for_version() {
   local version=$1
 
-  if [[ "$version" =~ ^[0-9]+\.* ]] ; then
-     # if version is a release number, prepend v
-     echo "https://repo.hex.pm/builds/elixir/v${version}.zip"
-  else
-     # otherwise it can be a branch name or commit sha
-     echo "https://repo.hex.pm/builds/elixir/${version}.zip"
+  # if version is a release number, prepend v
+  if [[ "$version" =~ ^[0-9]+\.* ]]; then
+    version="v${version}"
   fi
+
+  echo "https://repo.hex.pm/builds/elixir/${version}.zip"
 }
 
 

--- a/bin/install
+++ b/bin/install
@@ -30,7 +30,7 @@ install_elixir_version() {
 
   # path to the tar file
   local source_path="$tmp_download_dir/elixir-precompiled-${version}.zip"
-  download_source_file_for_version $version $source_path
+  download_zip_file_for_version $version $source_path
 
   echo "==> Copying release into place"
 
@@ -50,7 +50,7 @@ install_elixir_ref() {
 
   # path to the tar file
   local source_path="$tmp_download_dir/elixir-ref-${version}-src.tar.gz"
-  download_source_file_for_ref $ref $source_path
+  download_source_archive_for_ref $ref $source_path
 
   echo "==> Making the release"
 
@@ -65,7 +65,7 @@ install_elixir_ref() {
 }
 
 
-download_source_file_for_version() {
+download_zip_file_for_version() {
   local version=$1
   local download_path=$2
   local download_url=$(get_download_url_for_version $version)
@@ -96,7 +96,7 @@ EOS
 }
 
 
-download_source_file_for_ref() {
+download_source_archive_for_ref() {
   local ref=$1
   local download_path=$2
   local download_url="https://github.com/elixir-lang/elixir/archive/${ref}.tar.gz"


### PR DESCRIPTION
Why:

- The install script uses a recurrent logical branching around install type, which forces the multiple layers of functions to pass this value throughout the entire flow.
- The install script also has some redundant details in the messages shown to the user that can be simplified.
- From #78, when the connection to the releases server fails the error message redirects users to the Elixir repo on GitHub. However known versions are installed from hex.pm.

These changes address the issue by:

- Following up on #77, and addressing the full scope of #78, refactoring `bin/install` in four distinct steps, one in each commit for easier review.

  These changes remove most of the logical branching around the install type and cleanup some of the associated code.