### PR TITLE
Correct version check when trying to download zip file

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -75,7 +75,7 @@ download_zip_file_for_version() {
   echo "==> Checking whether specified Elixir release exists..."
   http_status=$(curl -I -w %{http_code} -s -o /dev/null $download_url)
 
-  if [ $http_status -eq 404 ]; then
+  if [ $http_status -eq 404 ] || [ $http_status -eq 403 ]; then
     cat <<EOS
 ==> Elixir version not found.
 


### PR DESCRIPTION
Sometimes invalid endpoints return status codes of 403. Both 404 and 403 should be considered not found in this case.

Fixes https://github.com/asdf-vm/asdf/issues/701