### PR TITLE
Fix variable usage on install_elixir_ref

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -47,7 +47,7 @@ install_elixir_ref() {
   local tmp_download_dir=$3
 
   # path to the tar file
-  local source_path="$tmp_download_dir/elixir-ref-${version}-src.tar.gz"
+  local source_path="$tmp_download_dir/elixir-ref-${ref}-src.tar.gz"
   download_source_archive_for_ref $ref $source_path
 
   echo "==> Making the release"


### PR DESCRIPTION
Even though the `install_elixir_ref` command works correctly, ir relies in an unexpected variable scoping behavior. In bash, local variables from the caller apparently leak to callees, even overrides are allowed.
    
https://stackoverflow.com/q/41770139/458304