### PR TITLE
Improve install error message

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -79,7 +79,7 @@ download_zip_file_for_version() {
     cat <<EOS
 ==> Elixir version not found.
 
-Hex.pm returned a 404 for the following URL:
+Hex.pm returned a ${http_status} for the following URL:
 
 ${download_url}
 


### PR DESCRIPTION
By showing the actual HTTP status code we can have a little more insight into what exactly went wrong.