### PR TITLE
add .mix to bin path

### DIFF
--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # let asdf create shims for installed escripts
-echo bin .mix/escripts
+echo bin .mix/escripts .mix


### PR DESCRIPTION
Makes asdf create shims for rebar and rebar3, as well as any other binaries which install themselves to $MIX_HOME
Fixes #44