### PR TITLE
Add auto install of hex and rebar

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-if [ "$MIX_ARCHIVES" = "" ]; then
-  export MIX_ARCHIVES=$ASDF_INSTALL_PATH/.mix/archives
-fi
-
 if [ "$MIX_HOME" = "" ]; then
   export MIX_HOME=$ASDF_INSTALL_PATH/.mix
+fi
+
+if [ "$MIX_ARCHIVES" = "" ]; then
+  export MIX_ARCHIVES=$MIX_HOME/archives
 fi
 
 

--- a/bin/install
+++ b/bin/install
@@ -18,6 +18,9 @@ install_elixir() {
   fi
 
   mkdir -p $install_path/.mix/archives
+
+  MIX_ARCHIVES=$install_path/.mix/archives $install_path/bin/mix local.hex --if-missing --force
+  MIX_HOME=$install_path/.mix $install_path/bin/mix local.rebar --if-missing --force
 }
 
 

--- a/bin/install
+++ b/bin/install
@@ -19,7 +19,7 @@ install_elixir() {
 
   mkdir -p $install_path/.mix/archives
 
-  MIX_ARCHIVES=$install_path/.mix/archives $install_path/bin/mix local.hex --if-missing --force
+  MIX_HOME=$install_path/.mix $install_path/bin/mix local.hex --if-missing --force
   MIX_HOME=$install_path/.mix $install_path/bin/mix local.rebar --if-missing --force
 }
 


### PR DESCRIPTION
After installing an Elixir version I'm always running into the fact that I have to add rebar and hex because it's a new version. Theoretically some of it can be shared across versions, but given some tickets I read that seems hard to track and might break. This however just automates a manual step that *most* users are now running manually. We can also hide it behind an ENV variable if that is preferable, but I don't think it harms the user in any way.