### PR TITLE
Revert "Add auto install of hex and rebar"

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-if [ "$MIX_HOME" = "" ]; then
-  export MIX_HOME=$ASDF_INSTALL_PATH/.mix
+if [ "$MIX_ARCHIVES" = "" ]; then
+  export MIX_ARCHIVES=$ASDF_INSTALL_PATH/.mix/archives
 fi
 
-if [ "$MIX_ARCHIVES" = "" ]; then
-  export MIX_ARCHIVES=$MIX_HOME/archives
+if [ "$MIX_HOME" = "" ]; then
+  export MIX_HOME=$ASDF_INSTALL_PATH/.mix
 fi
 
 

--- a/bin/install
+++ b/bin/install
@@ -18,9 +18,6 @@ install_elixir() {
   fi
 
   mkdir -p $install_path/.mix/archives
-
-  MIX_HOME=$install_path/.mix $install_path/bin/mix local.hex --if-missing --force
-  MIX_HOME=$install_path/.mix $install_path/bin/mix local.rebar --if-missing --force
 }
 
 


### PR DESCRIPTION
Reverts asdf-vm/asdf-elixir#89

For context: https://github.com/asdf-vm/asdf-elixir/issues/90

This revert doesn't attempt to fix the functionality introduced in asdf-vm/asdf-elixir#89, just roll it back to fix `asdf install` functionality until a proper fix is in place.