### PR TITLE
Reverting changes from upstream's PR #89.

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
+if [ "$MIX_ARCHIVES" = "" ]; then
+  export MIX_ARCHIVES=$ASDF_INSTALL_PATH/.mix/archives
+fi
+
 if [ "$MIX_HOME" = "" ]; then
   export MIX_HOME=$ASDF_INSTALL_PATH/.mix
 fi
-
-if [ "$MIX_ARCHIVES" = "" ]; then
-  export MIX_ARCHIVES=$MIX_HOME/archives
-fi
-
 

--- a/bin/install
+++ b/bin/install
@@ -18,9 +18,6 @@ install_elixir() {
   fi
 
   mkdir -p $install_path/.mix/archives
-
-  MIX_HOME=$install_path/.mix $install_path/bin/mix local.hex --if-missing --force
-  MIX_HOME=$install_path/.mix $install_path/bin/mix local.rebar --if-missing --force
 }
 
 


### PR DESCRIPTION
This should resolve issues running `asdf install`, where the mix commands added to `bin/install` were erroring out.