### PR TITLE
Add auto install of hex and rebar including path of the freshly installed elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ This plugin supports elixir escripts, adding them to your path just like any oth
 Whenever you install a new escript with `mix escript.install` you need to `asdf reshim elixir` in order
 to create shims for it.
 
+## Default `mix` commands
+
+After installing you can specify which additional mix commands must be run after adding a new Elixir version.
+This can be particurlarly useful for installing often used archives.
+They need to be specified in `$HOME/.default-mix-commands`, the flag `--force` will be added by default.
+An example:
+
+```
+local.hex
+local.rebar
+archive.install hex phx_new
+```
 
 ## Use
 

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-if [ "$MIX_ARCHIVES" = "" ]; then
-  export MIX_ARCHIVES=$ASDF_INSTALL_PATH/.mix/archives
-fi
-
 if [ "$MIX_HOME" = "" ]; then
   export MIX_HOME=$ASDF_INSTALL_PATH/.mix
+fi
+
+if [ "$MIX_ARCHIVES" = "" ]; then
+  export MIX_ARCHIVES=$MIX_HOME/archives
 fi

--- a/bin/install
+++ b/bin/install
@@ -149,4 +149,18 @@ get_download_url_for_version() {
   echo "https://repo.hex.pm/builds/elixir/${version}.zip"
 }
 
+run_default_mix_commands() {
+  local install_path=$1
+  local default_mix_commands="${HOME}/.default-mix-commands"
+
+  if [ ! -f "$default_mix_commands" ]; then return; fi
+
+  while read -u 7 -ra command; do
+    echo -e "\nRunning \033[33mmix ${command[@]} --force\033[39m... "
+    source "$(dirname "$0")/exec-env"
+    PATH=$install_path/bin:$PATH $install_path/bin/mix "${command[@]}" --force
+  done 7<"$default_mix_commands"
+}
+
 install_elixir "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+run_default_mix_commands "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -156,9 +156,10 @@ run_default_mix_commands() {
   if [ ! -f "$default_mix_commands" ]; then return; fi
 
   while read -u 7 -ra command; do
-    echo -e "\nRunning \033[33mmix ${command[@]} --force\033[39m... "
+    echo -e "\nRunning \033[33mmix ${command[*]} --force\033[39m... "
+    # shellcheck source=bin/exec-env
     source "$(dirname "$0")/exec-env"
-    PATH=$install_path/bin:$PATH MIX_EXS="" $install_path/bin/mix "${command[@]}" --force
+    PATH=$install_path/bin:$PATH MIX_EXS="" "$install_path"/bin/mix "${command[@]}" --force
   done 7<"$default_mix_commands"
 }
 

--- a/bin/install
+++ b/bin/install
@@ -158,7 +158,7 @@ run_default_mix_commands() {
   while read -u 7 -ra command; do
     echo -e "\nRunning \033[33mmix ${command[@]} --force\033[39m... "
     source "$(dirname "$0")/exec-env"
-    PATH=$install_path/bin:$PATH $install_path/bin/mix "${command[@]}" --force
+    PATH=$install_path/bin:$PATH MIX_EXS="" $install_path/bin/mix "${command[@]}" --force
   done 7<"$default_mix_commands"
 }
 


### PR DESCRIPTION
The problem was that the newly installed elixir wasn't in the path. This is because reshim happens after installation of elixir. There is no default post-install which could take place after the reshim.

I tested this on a fresh install and it worked.

@dobs would you be so kind to confirm if this fix is proper and working in your environment? Sorry for the trouble :)