### PR TITLE
Test plugin version as checked out by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: asdf plugin test elixir . --asdf-plugin-gitref $TRAVIS_BRANCH
+script: asdf plugin test elixir . --asdf-plugin-gitref $TRAVIS_COMMIT
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh


### PR DESCRIPTION
TRAVIS_BRANCH points to target branch in PRs

From the [documentation](https://docs.travis-ci.com/user/environment-variables/)
> TRAVIS_BRANCH:
>  - for push builds, or builds not triggered by a pull request, this is the name of the branch.
>  - for builds triggered by a pull request this is the name of the branch targeted by the pull request.
