### PR TITLE
Fix cp error on Mac OS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -70,7 +70,7 @@ install_elixir_ref() {
     exit 1
   else
     echo "Build succeeded!"
-    cp -rT $install_path/usr/local $install_path
+    cp -a $install_path/usr/local/. $install_path/
     rm -rf $install_path/usr
   fi
 }


### PR DESCRIPTION
The `cp` command doesn't have a `-T` switch on Mac OS:

```
Build succeeded!
cp: illegal option -- T
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file ... target_directory
```
