### PR TITLE
Fix error 'HTTP server doesn't seem to support byte ranges.'

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -83,7 +83,7 @@ download_zip_file_for_version() {
 
   # determine if the file exists
   echo "==> Checking whether specified Elixir release exists..."
-  http_status=$(curl -I -w %{http_code} -s -o /dev/null $download_url)
+  http_status=$(curl -L -I -w %{http_code} -s -o /dev/null $download_url)
 
   if [ $http_status -eq 404 ] || [ $http_status -eq 403 ]; then
     cat <<EOS
@@ -103,7 +103,7 @@ EOS
   fi
 
   echo "==> Downloading ${version} to ${download_path}"
-  curl -Lo $download_path -C - $download_url
+  curl -Lo $download_path $download_url
 }
 
 
@@ -114,7 +114,8 @@ download_source_archive_for_ref() {
 
   # determine if the file exists
   echo "==> Checking whether specified Elixir reference exists..."
-  http_status=$(curl -I -w %{http_code} -s -o /dev/null $download_url)
+  echo "Download url: $download_url"
+  http_status=$(curl -L -I -w %{http_code} -s -o /dev/null $download_url)
 
   if [ $http_status -eq 404 ]; then
     cat <<EOS
@@ -135,7 +136,7 @@ EOS
   fi
 
   echo "==> Downloading ${ref} to ${download_path}"
-  curl -Lo $download_path -C - $download_url
+  curl -Lo $download_path $download_url
 }
 
 


### PR DESCRIPTION
I get this error under Ubuntu 20.04:

```
$ asdf install elixir ref:v1.12.2
==> Checking whether specified Elixir reference exists...
==> Downloading v1.12.2 to /home/username/.asdf/downloads/elixir/ref-v1.12.2/elixir-ref-v1.12.2-src.tar.gz
\*\* Resuming transfer from byte position 14
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
100 127 100 127 0 0 2396 0 --:--:-- --:--:-- --:--:-- 2396
0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0
curl: (33) HTTP server doesn't seem to support byte ranges. Cannot resume.
==> Making the release

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

The culprit seems to be the second curl commands `-C -` bit. It's not clear to me why this should be there, because the curl command works fine without it. It would be a good idea to check it on MacOS first, which I can't do.

Also, i've added the `-L` flag to the does-the-release-exist curl command, so that it follows redirects and checks the existence of the actual file.