### PR TITLE
Add notes of ref install

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ asdf local elixir path:/path/to/elixir
 asdf global elixir path:/path/to/elixir
 ```
 
+> **Note**: Don't forget to compile erlang with xsltproc and fop libraries
+
 
 ### .tool-versions file
 


### PR DESCRIPTION
I have some troubles with ref:v1.11.4 on arch linux, mac os Big Sur. When i look at erlang libraries for compiling i understand what it must work for me, and it is. 