### PR TITLE
Tweak error message in case unzip is not installed

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -36,7 +36,8 @@ install_elixir_version() {
   echo "==> Copying release into place"
 
   if ! type "unzip" &> /dev/null; then
-    echo "ERROR: unzip not found"
+    echo "ERROR: Command 'unzip' not found."
+    echo "unzip must be installed on your system."
     exit 1
   fi
 


### PR DESCRIPTION
Provide a more actionable error message when unzip is not installed.
I lost half an hour until I realized what the error message 'ERROR: unzip not found' meant.

(I figured it out reading the source of this plugin.)

Only after that I found issue #53 and the accompanying PR.