### PR TITLE
Use new domain repo.hex.pm => builds.hex.pm

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -84,7 +84,7 @@ download_zip_file_for_version() {
 
   # determine if the file exists
   echo "==> Checking whether specified Elixir release exists..."
-  http_status=$(curl -I -w '%{http_code}' -s -o /dev/null "$download_url")
+  http_status=$(curl -L -I -w '%{http_code}' -s -o /dev/null "$download_url")
 
   if [ "$http_status" -eq 404 ] || [ "$http_status" -eq 403 ]; then
     cat <<EOS
@@ -114,7 +114,7 @@ download_source_archive_for_ref() {
 
   # determine if the file exists
   echo "==> Checking whether specified Elixir reference exists..."
-  http_status=$(curl -I -w '%{http_code}' -s -o /dev/null "$download_url")
+  http_status=$(curl -L -I -w '%{http_code}' -s -o /dev/null "$download_url")
 
   if [ "$http_status" -eq 404 ]; then
     cat <<EOS
@@ -146,7 +146,7 @@ get_download_url_for_version() {
     version="v${version}"
   fi
 
-  echo "https://repo.hex.pm/builds/elixir/${version}.zip"
+  echo "https://builds.hex.pm/builds/elixir/${version}.zip"
 }
 
 run_default_mix_commands() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -9,9 +9,9 @@
 # STDOUT. Otherwise, nothing is written to STDOUT and an error message is
 # written to STDERR.
 download_hex_pm_builds() {
-  local releases_url='https://repo.hex.pm/builds/elixir/builds.txt'
+  local releases_url='https://builds.hex.pm/builds/elixir/builds.txt'
 
-  if ! curl -fs $releases_url; then
+  if ! curl -Lfs $releases_url; then
     cat >&2 <<EOS
 ==> Failed to fetch Hex.pm versions list.
 
@@ -20,7 +20,7 @@ Hex.pm returned an error for the following URL:
 ${releases_url}
 
 Make sure your internet connection is stable and that you can reach
-https://hex.pm/.
+https://builds.hex.pm/.
 
 If the problem persists, please report it on GitHub:
 https://github.com/asdf-vm/asdf-elixir/issues/new


### PR DESCRIPTION
Also adds the curl flag `-L` to follow redirects. Since this was missing it unfortunately means that older versions of asdf-elixir we stop serving builds on repo.hex.pm and instead redirect to builds.hex.pm.