### PR TITLE
Avoid unbound variable error when nounset is enabled

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-if [ "$MIX_HOME" = "" ]; then
+if [ "${MIX_HOME:-}" = "" ]; then
   export MIX_HOME=$ASDF_INSTALL_PATH/.mix
 fi
 
-if [ "$MIX_ARCHIVES" = "" ]; then
-  export MIX_ARCHIVES=$MIX_HOME/archives
+if [ "${MIX_ARCHIVES:-}" = "" ]; then
+  export MIX_ARCHIVES=${MIX_HOME:-}/archives
 fi


### PR DESCRIPTION
If you are using **asdf-direnv** with **asdf-elixir** and try to execute
the command `asdf direnv shell elixir $version -- echo "hi"` will raise
the error "unbound variable" because the `direnv` uses `set -u` by
default.

I got this error when I try to setup this hook on `~/.asdfrc` to always
install the `local.hex` and `local.rebar`:
```
post_asdf_install_elixir = asdf direnv shell elixir $version -- mix do local.hex --force, local.rebar --force

```

The hack was always use a empty string if the variable is not defined.

But is possible to add a `set +u` at the beginning of the file and `set -u`
at the end, but set `set -u` at the end can cause a unexpected side
effect for another script.
