### PR TITLE
Updates doc URL for compatibility between elixir and erlang

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
 
 ## Check compatibility between elixir and erlang:
 
-https://hexdocs.pm/elixir/master/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
+https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
 
 ## Elixir precompiled versions
 


### PR DESCRIPTION
The URL currently in the README links to a 404 on hexdocs. This updates that URL in the README.