### PR TITLE
docs(install): replace plugin-add

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you have a Debian system you can install it by typing:
 > *Elixir requires Erlang to be installed. You can use the [asdf-erlang](https://github.com/asdf-vm/asdf-erlang) plugin to install Erlang versions.*
 
 ```
-asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
+asdf plugin add elixir https://github.com/asdf-vm/asdf-elixir.git
 ```
 
 ## Check compatibility between elixir and erlang:


### PR DESCRIPTION
Upcoming asdf release will not support the hyphenated `plugin-add`

ref
https://github.com/asdf-vm/asdf/blob/97c242eb38f49628486fd414743ff0e6539135da/docs/guide/upgrading-from-v0-15-to-v0-16.md?plain=1#L23