### PR TITLE
use --no-header flag only in latest asdf API (go builds) in latest-stable script

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -12,7 +12,12 @@ ASDF_ELIXIR_LATEST_VERSION=$(./list-all | tr " " "\n" | grep -Ev "^0|^main|^mast
 # gets current erlang version without headers
 # changes spaces to new line
 # takes second line (Name Version Source Installed)
-ASDF_ELIXIR_LATEST_OTP=$(asdf current --no-header erlang | tr -s " ." "\n" | sed -n 2p)
+if printf '0.16.0\n%s\n' $ASDF_VERSION | sort -CV; then
+  # use --no-header flag only in latest asdf API (go builds)
+  ASDF_ELIXIR_LATEST_OTP=$(asdf current --no-header erlang | tr -s " ." "\n" | sed -n 2p)
+else
+  ASDF_ELIXIR_LATEST_OTP=$(asdf current erlang | tr -s " ." "\n" | sed -n 2p)
+fi
 
 # Note: asdf latest does not allows latest stable version to start with number
 #       therefore installing from source by git ref is not supported, see:


### PR DESCRIPTION
**Note**: `v-dev` builds are seen as latest (> 0.16.0)

There might be a compatibility issues with older versions of sort (-V flag) on BSD/macOS or busybox. It would be helpful if @chvanikoff could test it on macOS as well just for sure.

This is an optional backwards-compatibility fix. Right now the latest-stable script works only on `>= 0.16.0` asdf versions. Based on discussion in #140 issue.