### PR TITLE
Update README to remove deprecated asdf installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,6 @@ asdf set --home elixir ref-<commit/tag reference>
 asdf set elixir ref-<commit/tag reference>
 ```
 
-**or asdf < 0.16.0**
-```bash
-# install in the entire environment
-asdf set --home elixir ref:<commit/tag reference>
-# Or install locally in project
-asdf set elixir ref:<commit/tag reference>
-```
-
 You can also [compile Elixir from source](https://github.com/elixir-lang/elixir/tree/master#compiling-from-source) without using `asdf` (for example, so that you can use the `master` branch of elixir or a branch with your own modifications), then use it by specifying the directory path:
 
 ```


### PR DESCRIPTION
PR #146 added separate instructions for asdf before and after 0.16, but PR #156 replaced the legacy commands with `asdf set`, making the pre-0.16 section incorrect. This PR removes that section and keeps only the current, correct setup.
